### PR TITLE
Limelight theme: font fallback

### DIFF
--- a/Resources/Themes/Limelight.css
+++ b/Resources/Themes/Limelight.css
@@ -1,5 +1,5 @@
 html {
-	font-family: "Dejavu Sans Mono";
+	font-family: "Dejavu Sans Mono", "Monaco", monospace;
 	font-size: 9pt;
 	background-color: #202020;
 	color: #FFFFFF;


### PR DESCRIPTION
Dejavu Sans Mono is not a standard font and there is no fallback set, so a non-monospace font will be chosen.
