### PR TITLE
Fix a bug that gets triggered by a nick change event with the same nicks

### DIFF
--- a/Classes/IRC/IRCChannel.m
+++ b/Classes/IRC/IRCChannel.m
@@ -276,6 +276,8 @@
 
 - (void)renameMember:(NSString*)fromNick to:(NSString*)toNick
 {
+    if ([fromNick isEqualToString:toNick]) return;
+    
 	int n = [self indexOfMember:fromNick];
 	if (n < 0) return;
 	


### PR DESCRIPTION
I use bip, and occasionally when a big backlog gets sent, it includes some nick change events where the new nick is the same as the old nick. That caused an exception to be raised in renameMember of IRCChanel.
