### PR TITLE
Make marked scroller work in Lion

### DIFF
--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -821,21 +821,19 @@
 	if (!version) {
 		Gestalt(gestaltSystemVersion, &version);
 	}
-	
-	if (version < 0x1070) {
-		NSScroller* old = [scrollView verticalScroller];
-		if (old && ![old isKindOfClass:[MarkedScroller class]]) {
-			if (scroller) {
-				[scroller removeFromSuperview];
-				[scroller release];
-			}
-			
-			scroller = [[MarkedScroller alloc] initWithFrame:NSMakeRect(-16, -64, 16, 64)];
-			scroller.dataSource = self;
-			[scroller setFloatValue:[old floatValue]];
-			[scroller setKnobProportion:[old knobProportion]];
-			[scrollView setVerticalScroller:scroller];
+
+	NSScroller* old = [scrollView verticalScroller];
+	if (old && ![old isKindOfClass:[MarkedScroller class]]) {
+		if (scroller) {
+			[scroller removeFromSuperview];
+			[scroller release];
 		}
+		
+		scroller = [[MarkedScroller alloc] initWithFrame:NSMakeRect(-16, -64, 16, 64)];
+		scroller.dataSource = self;
+		[scroller setFloatValue:[old floatValue]];
+		[scroller setKnobProportion:[old knobProportion]];
+		[scrollView setVerticalScroller:scroller];
 	}
 }
 

--- a/Classes/Views/MarkedScroller.m
+++ b/Classes/Views/MarkedScroller.m
@@ -8,11 +8,14 @@
 
 @synthesize dataSource;
 
++ (BOOL)isCompatibleWithOverlayScrollers {
+    return self == [MarkedScroller class];
+}
 
-- (void)drawRect:(NSRect)dirtyRect
+- (void)drawKnob
 {
-	[super drawRect:dirtyRect];
-	
+	[super drawKnob];
+
 	if (!dataSource) return;
 	if (![dataSource respondsToSelector:@selector(markedScrollerPositions:)]) return;
 	if (![dataSource respondsToSelector:@selector(markedScrollerColor:)]) return;
@@ -63,8 +66,6 @@
 	for (NSBezierPath* e in lines) {
 		[e stroke];
 	}
-	
-	[self drawKnob];
 }
 
 @end


### PR DESCRIPTION
This restores marked scroller functionality while not forfeiting the transparent scroller.
