### PR TITLE
Workaround for scrolling-redraw bug

### DIFF
--- a/Classes/Views/Log/WebViewAutoScroll.m
+++ b/Classes/Views/Log/WebViewAutoScroll.m
@@ -7,9 +7,13 @@
 @implementation WebViewAutoScroll
 - (void)scrollViewToBottom:(NSView*)aView
 {
+	if (![aView lockFocusIfCanDraw])
+		return;
+
 	NSRect visibleRect = [aView visibleRect];
 	visibleRect.origin.y = NSHeight([aView frame]) - NSHeight(visibleRect);
 	[aView scrollRectToVisible:visibleRect];
+	[aView unlockFocus];
 }
 
 - (void)dealloc


### PR DESCRIPTION
Sometimes when receiving a message, the context will fail to lock and the log window will only partially redraw. This workaround prevents the graphical corruption, but prevents it from scrolling to the bottom I'll look into how to get it to scroll more later.
