### PR TITLE
Disable rubber band scrolling for log view

### DIFF
--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -816,6 +816,9 @@
 	if ([scrollView respondsToSelector:@selector(setAllowsHorizontalScrolling:)]) {
 		[(id)scrollView setAllowsHorizontalScrolling:NO];
 	}
+	if ([scrollView respondsToSelector:@selector(setVerticalScrollElasticity:)]) {
+		[(id)scrollView setVerticalScrollElasticity:NSScrollElasticityNone];
+	}
 	
 	NSScroller* old = [scrollView verticalScroller];
 	if (old && ![old isKindOfClass:[MarkedScroller class]]) {


### PR DESCRIPTION
Since it's probably not possible to extend the log view's background over the page when rubber band scrolling, I've disabled rubber band scrolling when on Lion.
