### PR TITLE
Fix redraw issue introduced in 2.27

### DIFF
--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -608,7 +608,6 @@
 	}
 	[div setAttribute:@"id" value:[NSString stringWithFormat:@"line%d", currentLineNumber]];
 	[body appendChild:div];
-	[body valueForKey:@"scrollHeight"]; // Forces the view to recalculate instead of being lazy
 	
 	if (maxLines > 0 && count > maxLines) {
 		[self setNeedsLimitNumberOfLines];
@@ -619,6 +618,7 @@
 	}
 	
 	if (scroller) {
+		[scroller updateScroller];
 		[scroller setNeedsDisplay];
 	}
 	
@@ -853,6 +853,7 @@
 		autoScroller = [WebViewAutoScroll new];
 	}
 	autoScroller.webFrame = view.mainFrame.frameView;
+	autoScroller.scroller = scroller;
 	
 	if (html) {
 		DOMHTMLDocument* doc = (DOMHTMLDocument*)[[view mainFrame] DOMDocument];

--- a/Classes/Views/Log/WebViewAutoScroll.h
+++ b/Classes/Views/Log/WebViewAutoScroll.h
@@ -4,11 +4,14 @@
 #import <Foundation/Foundation.h>
 #import <WebKit/WebKit.h>
 
+#import "MarkedScroller.h"
 
 @interface WebViewAutoScroll : NSObject
 {
 	WebFrameView* webFrame;
 	NSRect lastFrame, lastVisibleRect;
+	MarkedScroller* scroller;
 }
 @property (nonatomic, assign) WebFrameView* webFrame;
+@property (nonatomic, retain) MarkedScroller* scroller;
 @end

--- a/Classes/Views/Log/WebViewAutoScroll.m
+++ b/Classes/Views/Log/WebViewAutoScroll.m
@@ -50,6 +50,8 @@
 	
 	//LOG(@"bounds changed: %@ → %@", NSStringFromRect(lastVisibleRect), NSStringFromRect([[clipView documentView] visibleRect]));
 	lastVisibleRect = [[clipView documentView] visibleRect];
+
+	[scroller updateScroller];
 }
 
 - (void)webViewDidChangeFrame:(NSNotification*)aNotification
@@ -79,7 +81,10 @@
 			[self scrollViewToBottom:[webFrame documentView]];
 		}
 	}
+
+	[scroller updateScroller];
 }
 
 @synthesize webFrame;
+@synthesize scroller;
 @end

--- a/Classes/Views/MarkedScroller.h
+++ b/Classes/Views/MarkedScroller.h
@@ -7,9 +7,13 @@
 @interface MarkedScroller : NSScroller
 {
 	id dataSource;
+	NSArray* markData;
 }
 
 @property (nonatomic, assign) id dataSource;
+@property (nonatomic, copy) NSArray* markData;
+
+- (void)updateScroller;
 
 @end
 

--- a/Classes/Views/MarkedScroller.m
+++ b/Classes/Views/MarkedScroller.m
@@ -7,12 +7,18 @@
 @implementation MarkedScroller
 
 @synthesize dataSource;
+@synthesize markData;
 
 const static int INSET = 3;
 
 + (BOOL)isCompatibleWithOverlayScrollers
 {
 	return self == [MarkedScroller class];
+}
+
+- (void)updateScroller
+{
+	self.markData = [dataSource markedScrollerPositions:self];
 }
 
 - (void)drawContentInMarkedScroller
@@ -23,8 +29,7 @@ const static int INSET = 3;
 	
 	NSScrollView* scrollView = (NSScrollView*)[self superview];
 	int contentHeight = [[scrollView contentView] documentRect].size.height;
-	NSArray* ary = [dataSource markedScrollerPositions:self];
-	if (!ary || !ary.count) return;
+	if (!markData || !markData.count) return;
 	
 	//
 	// prepare transform
@@ -43,7 +48,7 @@ const static int INSET = 3;
 	NSMutableArray* lines = [NSMutableArray array];
 	NSPoint prev = NSMakePoint(-1, -1);
 	
-	for (NSNumber* e in ary) {
+	for (NSNumber* e in markData) {
 		int i = [e intValue];
 		NSPoint pt = NSMakePoint(indent, i);
 		pt = [transform transformPoint:pt];


### PR DESCRIPTION
This fixes the redraw issue pertaining to the marked scroller and the chat log in 2.27.

The issue related to the fact that, upon updating the log view, the view itself did not immediately update, and the drawing code for the scrollbar could cause the view to update and try to draw itself while the scrollbar was drawing. This would cause contention, and the redraw would fail.

This patch solved the problem by caching the mark data so it's not queried during the scrollbar drawing.
