### PR TITLE
Bounce dock icon upon new message in existing private talk

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2492,8 +2492,7 @@ static NSDateFormatter* dateTimeFormatter;
                 id t = c ?: (id)self;
                 [self setUnreadState:t];
                 if (keyword) [self setKeywordState:t];
-                if (newTalk) [self setNewTalkState:t];
-                if (moreTalk) [self setNewTalkState:t];
+                if (newTalk || moreTalk) [self setNewTalkState:t];
                 
                 GrowlNotificationType kind = keyword ? GROWL_HIGHLIGHT : newTalk ? GROWL_NEW_TALK : GROWL_TALK_MSG;
                 [self notifyText:kind target:(c ?: (id)target) nick:nick text:text];


### PR DESCRIPTION
When someone starts a private talk with me, I get a blue badge and bouncing icon reminder, which is very useful.

However, I often find myself missing important messages in an existing private talk as the current version won't bounce upon a new private talk message. 

This patch fixes that. (As usual, we only get a bounce if the app is not active).
