### PR TITLE
Open chat on member list doubleclick instead of whois

### DIFF
--- a/Classes/Controllers/MenuController.m
+++ b/Classes/Controllers/MenuController.m
@@ -1028,7 +1028,7 @@
         if ([[view selectedRowIndexes] count] > 0) {
             [view selectItemAtIndex:n];
         }
-        [self whoisSelectedMembers:nil deselect:NO];
+        [self onMemberTalk:nil];
     }
 }
 


### PR DESCRIPTION
This is something that has long bothered me about Limechat, I would appreciate if you merged this.

If you think this would be better as an option I totally submit to your judgement, but please don't just ignore this patch.

I personally feel this should be the default, if not the only behavior of double-clicking a username in a channel member list.  I have never used any chat program (IRC or otherwise) in which double-clicking on a name in a user list did anything except initiate a private chat with the user.  I can honestly say that 100% of the time that is the behavior I expect from a chat program.  If I ever wanted extra info on the user (I've never found myself wanting that in IRC), I would right click and look for some sort of "more info" option in the context menu.

Please, for the love of :bear:, merge this or add an option so that we can have some logical behaviour on the member list.

Thanks.
