### PR TITLE
Support loading direct links to pixiv images

### DIFF
--- a/Classes/Library/ImageSizeCheckClient.m
+++ b/Classes/Library/ImageSizeCheckClient.m
@@ -45,9 +45,14 @@
 {
     [self cancel];
     
-    NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:url] cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:IMAGE_SIZE_CHECK_TIMEOUT];
+    NSURL *u = [NSURL URLWithString:url];
+    NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:u cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:IMAGE_SIZE_CHECK_TIMEOUT];
     [req setHTTPMethod:@"HEAD"];
     
+    if ([[u host] hasSuffix:@"pixiv.net"]) {
+        [req setValue:@"http://www.pixiv.net" forHTTPHeaderField:@"Referer"];
+    }
+
     conn = [[NSURLConnection alloc] initWithRequest:req delegate:self];
 }
 

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -1029,6 +1029,20 @@
     }
 }
 
+- (NSURLRequest *)webView:(WebView *)sender
+                 resource:(id)identifier
+          willSendRequest:(NSURLRequest *)request
+         redirectResponse:(NSURLResponse *)redirectResponse
+           fromDataSource:(WebDataSource *)dataSource;
+{
+    if ([[[request URL] host] hasSuffix:@"pixiv.net"]) {
+        NSMutableURLRequest *req = [request mutableCopy];
+        [req setValue:@"http://www.pixiv.net" forHTTPHeaderField:@"Referer"];
+        return req;
+    }
+    return request;
+}
+
 #pragma mark -
 #pragma mark LogView Delegate
 


### PR DESCRIPTION
Pixiv images do a referer check before allowing load. This bypasses
the referer check by sending http://www.pixiv.net as the image's
referer.
