### PR TITLE
Thumbnail support for regular pixiv image URLs

### DIFF
--- a/Classes/Controllers/PixivSchemaManager.h
+++ b/Classes/Controllers/PixivSchemaManager.h
@@ -1,0 +1,26 @@
+// LimeChat is copyrighted free software by Satoshi Nakagawa <psychs AT limechat DOT net>.
+// You can redistribute it and/or modify it under the terms of the GPL version 2 (see the file GPL.txt).
+
+#import <Foundation/Foundation.h>
+#import "IRCClient.h"
+#import "ImageSizeCheckClient.h"
+
+@interface PixivSchemaManager : NSObject
+{
+    NSMutableSet* clients;
+    __weak IRCWorld *world;
+}
+
+@property (nonatomic, weak) IRCWorld* world;
+
++ (PixivSchemaManager*)instance;
++ (void)disposeInstance;
+
+- (void)beginGetImageURL:(NSString *)illustId forClient:(ImageSizeCheckClient *)client;
+
+@end
+
+@interface NSObject (PixivSchemaManagerDelegate)
+- (void)pixivImageURLObtained:(NSURL *)url;
+- (void)pixivImageURLFailed:(NSError *)error;
+@end

--- a/Classes/Controllers/PixivSchemaManager.m
+++ b/Classes/Controllers/PixivSchemaManager.m
@@ -1,0 +1,70 @@
+// LimeChat is copyrighted free software by Satoshi Nakagawa <psychs AT limechat DOT net>.
+// You can redistribute it and/or modify it under the terms of the GPL version 2 (see the file GPL.txt).
+
+#import "PixivSchemaManager.h"
+#import "PixivIllustClient.h"
+
+static PixivSchemaManager* instance;
+
+@implementation PixivSchemaManager
+
+@synthesize world;
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        clients = [NSMutableSet new];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [clients makeObjectsPerformSelector:@selector(cancel)];
+    [clients release];
+    [super dealloc];
+}
+
++ (PixivSchemaManager *)instance
+{
+    if (!instance)
+        instance = [PixivSchemaManager new];
+    return instance;
+}
+
++ (void)disposeInstance
+{
+    [instance release];
+    instance = nil;
+}
+
+- (void)beginGetImageURL:(NSString *)imageId forClient:(ImageSizeCheckClient *)client
+{
+    PixivIllustClient *c = [PixivIllustClient newWithIllustId:imageId];
+    c.delegate = self;
+    c.client = client;
+    [c beginQuery];
+    [clients addObject:c];
+}
+
+
+- (void)pixivClient:(PixivIllustClient *)sender gotPixivIllustURL:(NSURL *)url
+{
+    [[sender retain] autorelease];
+    [clients removeObject:sender];
+
+    if ([sender.client respondsToSelector:@selector(pixivImageURLObtained:)])
+        [sender.client pixivImageURLObtained:url];
+}
+
+- (void)pixivClient:(PixivIllustClient *)sender gotError:(NSError *)error
+{
+    [[sender retain] autorelease];
+    [clients removeObject:sender];
+
+    if ([sender.client respondsToSelector:@selector(pixivImageURLFailed:)])
+        [sender.client pixivImageURLFailed:error];
+}
+
+@end

--- a/Classes/Library/ImageSizeCheckClient.h
+++ b/Classes/Library/ImageSizeCheckClient.h
@@ -15,6 +15,7 @@
     int lineNumber;
     int imageIndex;
 
+    NSMutableURLRequest* req;
     NSURLConnection* conn;
     NSHTTPURLResponse* response;
 }

--- a/Classes/Library/PixivIllustClient.h
+++ b/Classes/Library/PixivIllustClient.h
@@ -1,0 +1,32 @@
+// LimeChat is copyrighted free software by Satoshi Nakagawa <psychs AT limechat DOT net>.
+// You can redistribute it and/or modify it under the terms of the GPL version 2 (see the file GPL.txt).
+
+#import <Foundation/Foundation.h>
+#import <WebKit/WebKit.h>
+#import "ImageSizeCheckClient.h"
+
+@interface PixivIllustClient : NSObject
+{
+    WebView* webView;
+    __weak id delegate;
+    __weak ImageSizeCheckClient* client;
+    NSString* illustId;
+    NSURL *requestURL;
+    bool loggingIn;
+}
+
+@property (nonatomic, weak) id delegate;
+@property (nonatomic, weak) ImageSizeCheckClient* client;
+@property (nonatomic, copy) NSString* illustId;
+
++ (PixivIllustClient *)newWithIllustId:(NSString *)illustId;
+
+- (void)cancel;
+- (void)beginQuery;
+
+@end
+
+@interface NSObject (PixivIllustClientDelegate)
+- (void)pixivClient:(PixivIllustClient *)sender gotPixivIllustURL:(NSURL *)url;
+- (void)pixivClient:(PixivIllustClient *)sender gotError:(NSError *)error;
+@end

--- a/Classes/Library/PixivIllustClient.m
+++ b/Classes/Library/PixivIllustClient.m
@@ -1,0 +1,99 @@
+// LimeChat is copyrighted free software by Satoshi Nakagawa <psychs AT limechat DOT net>.
+// You can redistribute it and/or modify it under the terms of the GPL version 2 (see the file GPL.txt).
+
+#import "PixivIllustClient.h"
+#import "PixivSchemaManager.h"
+#import "Preferences.h"
+
+#define PIXIV_ILLUST_FORMAT @"http://www.pixiv.net/member_illust.php?mode=medium&illust_id=%@"
+
+@implementation PixivIllustClient
+
+@synthesize delegate, client, illustId;
+
+- (id)init
+{
+    self = [super init];
+    if (self) {
+        webView = [[WebView alloc] init];
+        webView.frameLoadDelegate    = self;
+        webView.resourceLoadDelegate = self;
+        loggingIn = NO;
+    }
+    return self;
+}
+
++ (PixivIllustClient *)newWithIllustId:(NSString *)illustId
+{
+    PixivIllustClient *c = [PixivIllustClient new];
+    c.illustId = illustId;
+    return c;
+}
+
+- (void)dealloc
+{
+    [self cancel];
+    [webView release];
+    webView = nil;
+    [requestURL release];
+    requestURL = nil;
+    [super dealloc];
+}
+
+- (void)cancel
+{
+    [[webView mainFrame] stopLoading];
+}
+
+- (void)beginQuery
+{
+    [self cancel];
+
+    requestURL = [NSURL URLWithString:[NSString stringWithFormat:PIXIV_ILLUST_FORMAT, illustId]];
+    [requestURL retain];
+    NSMutableURLRequest* req = [NSMutableURLRequest requestWithURL:requestURL];
+
+    [[webView mainFrame] loadRequest:req];
+}
+
+- (void)webView:(WebView *)sender didFinishLoadForFrame:(WebFrame *)frame
+{
+    if (frame != [webView mainFrame])
+        return;
+    DOMDocument *doc = [frame DOMDocument];
+
+    DOMElement *meta = [doc querySelector:@"meta[property=\"og:image\"]"];
+    NSMutableString *img = nil;
+    if (meta)
+        img = [[[meta getAttribute:@"content"] mutableCopy] autorelease];
+
+    if (!img) // bail
+    {
+        NSLog(@"og:image for Pixiv ID %@ could not be extracted", illustId);
+        if ([delegate respondsToSelector:@selector(pixivClient:gotError::)])
+            [delegate pixivClient:self gotError:[NSError errorWithDomain:@"Pixiv Client" code:-1 userInfo:nil]];
+        return;
+    }
+
+    /* _s images are too small; we're going to use _m images from the 320x320 folder.
+       They're not as small as _s but not as large as regular _m images. */
+    [img replaceOccurrencesOfString:@"_s." withString:@"_m." options:0 range:NSMakeRange(0, [img length])];
+    [img replaceOccurrencesOfString:@"/img/" withString:@"/dic/320x320/" options:0 range:NSMakeRange(0, [img length])];
+
+    NSURL *url = [NSURL URLWithString:img];
+    if ([delegate respondsToSelector:@selector(pixivClient:gotPixivIllustURL:)])
+        [delegate pixivClient:self gotPixivIllustURL:url];
+}
+
+- (NSURLRequest *)webView:(WebView *)sender resource:(id)identifier willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse fromDataSource:(WebDataSource *)dataSource
+{
+    /* WebKit wants to load *everything* that's referenced from the page;
+       we only need the HTML */
+    if (redirectResponse)
+        return request;
+    if ([[request URL] isEqual:requestURL])
+        return request;
+    return nil;
+}
+
+@end

--- a/Classes/Views/Log/ImageURLParser.h
+++ b/Classes/Views/Log/ImageURLParser.h
@@ -7,6 +7,7 @@
 @interface ImageURLParser : NSObject
 
 + (BOOL)isImageFileURL:(NSString*)url;
++ (BOOL)isPixivURL:(NSString*)url;
 + (NSString*)serviceImageURLForURL:(NSString*)url;
 
 @end

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -362,7 +362,17 @@
             [self savePosition];
             
             DOMHTMLElement* imageAnchorTag = (DOMHTMLElement*)[doc createElement:@"a"];
-            [imageAnchorTag setAttribute:@"href" value:url];
+            NSURL *u = [NSURL URLWithString:url];
+            if ([[u host] hasSuffix:@"pixiv.net"])
+            {
+                NSScanner *sc = [NSScanner scannerWithString:[u lastPathComponent]];
+                NSInteger illustId = 0;
+                [sc scanInteger:&illustId];
+                NSString *str = [NSString stringWithFormat:@"http://www.pixiv.net/member_illust.php?mode=medium&illust_id=%ld", illustId];
+                [imageAnchorTag setAttribute:@"href" value:str];
+            }
+            else
+                [imageAnchorTag setAttribute:@"href" value:url];
             [imageAnchorTag setAttribute:@"imageindex" value:[NSString stringWithFormat:@"%d", imageIndex]];
             
             NSString* imageAnchorTagContent = [NSString stringWithFormat:@"<img src=\"%@\" class=\"inlineimage\"/>", url];
@@ -571,8 +581,15 @@
             
             BOOL isFileURL = NO;
             BOOL checkingSize = NO;
-            
-            if ([ImageURLParser isImageFileURL:url]) {
+            BOOL isPixiv = NO;
+
+            if ((isPixiv = [ImageURLParser isPixivURL:url])) {
+                NSString *newUrl = [ImageURLParser serviceImageURLForURL:url];
+                if (newUrl)
+                    url = newUrl;
+            }
+
+            if ([ImageURLParser isImageFileURL:url] || isPixiv) {
                 isFileURL = YES;
                 if (![url hasPrefix:@"http://gyazo.com/"]) {
                     checkingSize = YES;

--- a/LimeChat.xcodeproj/project.pbxproj
+++ b/LimeChat.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2BB3DA0E15C8D23B000EAE51 /* PixivSchemaManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BB3DA0D15C8D23B000EAE51 /* PixivSchemaManager.m */; };
+		2BB3DA1115C8D33C000EAE51 /* PixivIllustClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 2BB3DA1015C8D33C000EAE51 /* PixivIllustClient.m */; };
 		780844D2134CD34B003BB84C /* ImageDownloadManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 780844D1134CD34B003BB84C /* ImageDownloadManager.m */; };
 		780844D3134CD34B003BB84C /* ImageDownloadManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 780844D1134CD34B003BB84C /* ImageDownloadManager.m */; };
 		780844F6134CD45E003BB84C /* ImageSizeCheckClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 780844F5134CD45E003BB84C /* ImageSizeCheckClient.m */; };
@@ -360,6 +362,10 @@
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		2BB3DA0C15C8D23B000EAE51 /* PixivSchemaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PixivSchemaManager.h; sourceTree = "<group>"; };
+		2BB3DA0D15C8D23B000EAE51 /* PixivSchemaManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PixivSchemaManager.m; sourceTree = "<group>"; };
+		2BB3DA0F15C8D33C000EAE51 /* PixivIllustClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PixivIllustClient.h; sourceTree = "<group>"; };
+		2BB3DA1015C8D33C000EAE51 /* PixivIllustClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PixivIllustClient.m; sourceTree = "<group>"; };
 		780253C20C09525900C170D4 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = /System/Library/Frameworks/CoreServices.framework; sourceTree = "<absolute>"; };
 		780844D0134CD34B003BB84C /* ImageDownloadManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImageDownloadManager.h; sourceTree = "<group>"; };
 		780844D1134CD34B003BB84C /* ImageDownloadManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ImageDownloadManager.m; sourceTree = "<group>"; };
@@ -802,6 +808,8 @@
 				78A8C0C911737F660044E7A1 /* NickCompletinStatus.m */,
 				787F49401589809F003AADE2 /* TwitterAvatarURLManager.h */,
 				787F49411589809F003AADE2 /* TwitterAvatarURLManager.m */,
+				2BB3DA0C15C8D23B000EAE51 /* PixivSchemaManager.h */,
+				2BB3DA0D15C8D23B000EAE51 /* PixivSchemaManager.m */,
 			);
 			name = Controllers;
 			path = Classes/Controllers;
@@ -982,6 +990,8 @@
 				78A8C14411737F660044E7A1 /* TCPServer.m */,
 				78A8C14511737F660044E7A1 /* Timer.h */,
 				78A8C14611737F660044E7A1 /* Timer.m */,
+				2BB3DA0F15C8D33C000EAE51 /* PixivIllustClient.h */,
+				2BB3DA1015C8D33C000EAE51 /* PixivIllustClient.m */,
 			);
 			name = Library;
 			path = Classes/Library;
@@ -1532,6 +1542,8 @@
 				78AB172715C33374008CD998 /* NumericTextField.m in Sources */,
 				78AB173315C37287008CD998 /* GrowlNotificationController.m in Sources */,
 				78A3004E15C38FB2003263AA /* UserNotificationController.m in Sources */,
+				2BB3DA0E15C8D23B000EAE51 /* PixivSchemaManager.m in Sources */,
+				2BB3DA1115C8D33C000EAE51 /* PixivIllustClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Regular pixiv URLs don't have enough information in the URL to derive the
image's URL, so we have to do some HTML parsing. Since we can't block or the UI
freezes, we do the request as part of ImageSizeCheckClient's check.

Pixiv URLs also need a bit of special treatment. Clicking the thumbnail would
open the direct link to the image in the browser, which isn't very useful because
you would get a 403 back (or a small image), so we inject a link to the web
interface for the image.

This (apparently) passes Instruments' Zombie check and Leak check;
slowly learning the Obj-C memory management stuff...
