### PR TITLE
Allow ~ to start channel name

### DIFF
--- a/Classes/Helpers/NSStringHelper.m
+++ b/Classes/Helpers/NSStringHelper.m
@@ -270,7 +270,7 @@ static BOOL isUnicharDigit(unichar c)
 {
     if (self.length == 0) return NO;
     UniChar c = [self characterAtIndex:0];
-    return c == '#' || c == '&' || c == '+' || c == '!';
+    return c == '#' || c == '&' || c == '+' || c == '!' || c == '~';
 }
 
 - (BOOL)isModeChannelName


### PR DESCRIPTION
Useful for ZNC partyline channels which are named as ~#channelName
