### PR TITLE
Fix: Use the current locale for CTCP-Time replies.

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2554,7 +2554,7 @@
             [self sendCTCPReply:nick command:command text:s];
         }
         else if ([command isEqualToString:TIME]) {
-            NSString* text = [[NSDate date] description];
+            NSString* text = [[NSDate date] descriptionWithLocale:[NSLocale currentLocale]];
             [self sendCTCPReply:nick command:command text:text];
         }
         else if ([command isEqualToString:VERSION]) {


### PR DESCRIPTION
CTCP Time is supposed to return the local time of the client,
not the GMT time which [[NSDate date] description] returns.

https://en.wikipedia.org/wiki/Client-to-client_protocol#Common_CTCP_Commands

Before:

```
2013-01-10 19:02:50 +0000
```

After:

```
Thursday, January 10, 2013 7:02:50 PM Central European Time
```
