### PR TITLE
Don't expand image URLs that don't really point to images.

### DIFF
--- a/Classes/Controllers/ImageDownloadManager.m
+++ b/Classes/Controllers/ImageDownloadManager.m
@@ -59,7 +59,7 @@ static ImageDownloadManager* instance;
 #pragma mark -
 #pragma mark ImageSizeCheckClient Delegate
 
-- (void)imageSizeCheckClient:(ImageSizeCheckClient*)sender didReceiveContentLength:(long long)contentLength
+- (void)imageSizeCheckClient:(ImageSizeCheckClient*)sender didReceiveContentLength:(long long)contentLength andType:(NSString*)contentType
 {
     [[sender retain] autorelease];
     [checkers removeObject:sender];
@@ -82,7 +82,7 @@ static ImageDownloadManager* instance;
     }
 
     if (log) {
-        [log expandImage:sender.url lineNumber:sender.lineNumber imageIndex:sender.imageIndex contentLength:contentLength];
+        [log expandImage:sender.url lineNumber:sender.lineNumber imageIndex:sender.imageIndex contentLength:contentLength contentType:contentType];
     }
 }
 

--- a/Classes/Library/ImageSizeCheckClient.h
+++ b/Classes/Library/ImageSizeCheckClient.h
@@ -33,6 +33,8 @@
 
 
 @interface NSObject (ImageSizeCheckClientDelegate)
-- (void)imageSizeCheckClient:(ImageSizeCheckClient*)sender didReceiveContentLength:(long long)contentLength;
+- (void)imageSizeCheckClient:(ImageSizeCheckClient*)sender
+     didReceiveContentLength:(long long)contentLength
+                     andType:(NSString*)contentType;
 - (void)imageSizeCheckClient:(ImageSizeCheckClient*)sender didFailWithError:(NSError*)error statusCode:(int)statusCode;
 @end

--- a/Classes/Library/ImageSizeCheckClient.m
+++ b/Classes/Library/ImageSizeCheckClient.m
@@ -77,6 +77,7 @@
     if (conn != sender) return;
 
     long long contentLength = 0;
+    NSString* contentType;
     int statusCode = [response statusCode];
 
     if (200 <= statusCode && statusCode < 300) {
@@ -85,11 +86,12 @@
         if ([contentLengthNum respondsToSelector:@selector(longLongValue)]) {
             contentLength = [contentLengthNum longLongValue];
         }
+        contentType = [header objectForKey:@"Content-Type"];
     }
 
     if (contentLength) {
-        if ([delegate respondsToSelector:@selector(imageSizeCheckClient:didReceiveContentLength:)]) {
-            [delegate imageSizeCheckClient:self didReceiveContentLength:contentLength];
+        if ([delegate respondsToSelector:@selector(imageSizeCheckClient:didReceiveContentLength:andType:)]) {
+            [delegate imageSizeCheckClient:self didReceiveContentLength:contentLength andType:contentType];
         }
     }
     else {

--- a/Classes/Views/Log/ImageURLParser.h
+++ b/Classes/Views/Log/ImageURLParser.h
@@ -7,6 +7,7 @@
 @interface ImageURLParser : NSObject
 
 + (BOOL)isImageFileURL:(NSString*)url;
++ (BOOL)isImageContent:(NSString*)contentType;
 + (NSString*)serviceImageURLForURL:(NSString*)url;
 
 @end

--- a/Classes/Views/Log/ImageURLParser.m
+++ b/Classes/Views/Log/ImageURLParser.m
@@ -17,6 +17,14 @@
     || [lowerUrl hasSuffix:@".svg"];
 }
 
++ (BOOL)isImageContent:(NSString*)contentType
+{
+    return [contentType isEqual:@"image/jpeg"]
+    || [contentType isEqual:@"image/png"]
+    || [contentType isEqual:@"image/svg+xml"]
+    || [contentType isEqual:@"image/gif"];
+}
+
 + (NSString*)serviceImageURLForURL:(NSString*)url
 {
     NSString* encodedUrl = [url encodeURIFragment];

--- a/Classes/Views/Log/LogController.h
+++ b/Classes/Views/Log/LogController.h
@@ -81,7 +81,7 @@
 - (void)reloadTheme;
 - (void)clear;
 - (void)changeTextSize:(BOOL)bigger;
-- (void)expandImage:(NSString*)url lineNumber:(int)aLineNumber imageIndex:(int)imageIndex contentLength:(long long)contentLength;
+- (void)expandImage:(NSString*)url lineNumber:(int)aLineNumber imageIndex:(int)imageIndex contentLength:(long long)contentLength contentType:(NSString*)contentType;
 
 - (BOOL)print:(LogLine*)line;
 

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -302,9 +302,14 @@
     [self restorePosition];
 }
 
-- (void)expandImage:(NSString*)url lineNumber:(int)aLineNumber imageIndex:(int)imageIndex contentLength:(long long)contentLength
+- (void)expandImage:(NSString*)url lineNumber:(int)aLineNumber imageIndex:(int)imageIndex contentLength:(long long)contentLength contentType:(NSString*)contentType
 {
     if (!loaded) return;
+    
+    if (![ImageURLParser isImageContent:contentType]) {
+        LOG(@"Ignore non-image image URL: %@ (%@)", url, contentType);
+        return;
+    }
 
     if (contentLength > INLINE_IMAGE_MAX_SIZE) {
         LOG(@"Ignore too big image: %@ (%qi bytes)", url, contentLength);


### PR DESCRIPTION
Sometimes a URL will end with an image extension but points to something else instead, such as Wikimedia image summary pages. Limechat will try to thumbnail these resulting in a broken image inserted into the log. I added a Content-Type check to mitigate this.

![Screen Shot 2013-03-01 at 10 47 07 AM](https://f.cloud.github.com/assets/936355/210953/c2d1b2cc-82a3-11e2-8682-03e4bc5106f2.png)
