### PR TITLE
Make Command-{ and Command-} switch active channels.

### DIFF
--- a/Classes/Controllers/AppController.m
+++ b/Classes/Controllers/AppController.m
@@ -1021,6 +1021,8 @@ typedef enum {
     [self handler:@selector(showPasteDialog:) code:KEY_RETURN mods:NSAlternateKeyMask];
     [self handler:@selector(selectPreviousActiveChannel:) char:'[' mods:NSCommandKeyMask];
     [self handler:@selector(selectNextActiveChannel:) char:']' mods:NSCommandKeyMask];
+    [self handler:@selector(selectPreviousActiveChannel:) char:'{' mods:NSCommandKeyMask|NSShiftKeyMask];
+    [self handler:@selector(selectNextActiveChannel:) char:'}' mods:NSCommandKeyMask|NSShiftKeyMask];
     [self handler:@selector(selectPreviousChannel:) code:KEY_UP mods:NSControlKeyMask];
     [self handler:@selector(selectNextChannel:) code:KEY_DOWN mods:NSControlKeyMask];
     [self handler:@selector(selectPreviousServer:) code:KEY_LEFT mods:NSControlKeyMask];


### PR DESCRIPTION
This is the standard previous/next tab key-combination for many
applications like web browsers, terminal emulators, and other messaging
clients. It would be great if LimeChat also supported it.

This patch has been tested on OS X 10.8.3.
