### PR TITLE
Make channel name visible when app is inactive and active text/background are the same color

### DIFF
--- a/Classes/IRC/IRCWorld.m
+++ b/Classes/IRC/IRCWorld.m
@@ -1051,7 +1051,12 @@
     }
     else if (i.isActive) {
         if (i == [tree itemAtRow:[tree selectedRow]]) {
-            color = theme.treeSelActiveColor;
+            if ([NSApp isActive]) {
+                color = theme.treeSelActiveColor;
+            }
+            else {
+                color = theme.treeActiveColor;
+            }
         }
         else {
             color = theme.treeActiveColor;


### PR DESCRIPTION
When app is inactive and the channel highlight is removed, the channel name is not visible if the background and text are the same color.

Bad:
![screen shot 2013-07-01 at 11 42 22 pm](https://f.cloud.github.com/assets/763550/734670/9043d0aa-e2d5-11e2-8ed1-b7cdffd9e87e.png)

Good:
![screen shot 2013-07-02 at 1 15 01 am](https://f.cloud.github.com/assets/763550/734688/66945774-e2d6-11e2-8b94-b88e5edb38b0.png)
