### PR TITLE
Fix for Issue #155 - URL links with non ASCII characters break. Removes ...

### DIFF
--- a/Classes/Helpers/NSStringHelper.m
+++ b/Classes/Helpers/NSStringHelper.m
@@ -309,28 +309,6 @@ static BOOL isUnicharDigit(unichar c)
 
     NSRange r = [result rangeAtIndex:0];
 
-    // exclude non ASCII characters from URLs except for wikipedia
-    NSString* host = [[self substringWithRange:[result rangeAtIndex:2]] lowercaseString];
-    if (![host hasSuffix:@"wikipedia.org"]) {
-        NSRange pathRange = [result rangeAtIndex:3];
-        if (pathRange.length) {
-            static NSRegularExpression* pathRegex = nil;
-            if (!pathRegex) {
-                NSString* pathPattern = @"^/[a-zA-Z0-9\\-._~!#$%&'()*+,-./:;=?@\\[\\]]*";
-                pathRegex = [[NSRegularExpression alloc] initWithPattern:pathPattern options:0 error:NULL];
-            }
-
-            NSString* path = [self substringWithRange:pathRange];
-            NSRange newPathRange = [pathRegex rangeOfFirstMatchInString:path options:0 range:NSMakeRange(0, path.length)];
-            if (newPathRange.location != NSNotFound) {
-                int delta = pathRange.length - newPathRange.length;
-                if (delta > 0) {
-                    r.length -= delta;
-                }
-            }
-        }
-    }
-
     NSString* url = [self substringWithRange:r];
     int len = url.length;
     const UniChar* buf = [url getCharactersBuffer];


### PR DESCRIPTION
...code from commit: https://github.com/psychs/limechat/commit/4851eda8aa78

If you see discussion from the issue itself, it was not easy to determine why this feature was designed as is. The current designed behavior would prevent users from properly inserting URL links into the chat window that contain special characters/non-ascii characters such as umlauts. At minimum if reverting the relevant commit to "fix" this issue is not recommended (due to what I assume is some kind of security concern) then the code should be modified to add additional domains; see issue #155 for specifics as to which domains to consider adding. If this latter course of action is recommend, please let me know, I'll be happy to do that instead of removing entirely the code in question.
