### PR TITLE
Fix for Issue #166, your long nick wraps incorrectly when using default ...

### DIFF
--- a/Resources/Themes/Limelight.css
+++ b/Resources/Themes/Limelight.css
@@ -118,7 +118,7 @@ body.normal .sender[type=normal], body.normal .sender[type=myself] {
 	float: left;
 	padding-right: 0.3ex;
 	text-align: right;
-	width: 20ex;
+	width: auto;
 }
 
 body.normal div.line[type=action] .sender[type=normal], div.line[type=action] .sender[type=myself] {


### PR DESCRIPTION
...Limelight theme. Simple edit to Limelight.css to prevent the issue from occurring. This bug while cosmetic, can give first time users using long nicks a bad first impression of Limechat. Fixing this small issue goes a long way to improving the user's perception of the application.
