### PR TITLE
Fix for Issue #170 - URLs with carat characters after the query string (...

### DIFF
--- a/Classes/Helpers/NSStringHelper.m
+++ b/Classes/Helpers/NSStringHelper.m
@@ -298,7 +298,7 @@ static BOOL isUnicharDigit(unichar c)
 
     static NSRegularExpression* regex = nil;
     if (!regex) {
-        NSString* pattern = @"(?<![a-z0-9_])(https?|ftp|itms|afp)://([^\\s!\"#$\\&'()*+,/;<=>?\\[\\\\\\]\\^_`{|}　、，。．・…]+)(/[^\\s\"`<>　、，。．・…]*)?";
+        NSString* pattern = @"(?<![a-z0-9_])(https?|ftp|itms|afp)://([^\\s!\"#$\\&'()*+,/;<=>?\\[\\\\\\]\\^_`{|}　、，。．・…]+)(/[^\\s\"`<>　、，。．・…]*)?(/[^\\s\"]*)";
         regex = [[NSRegularExpression alloc] initWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:NULL];
     }
 


### PR DESCRIPTION
...?) result in broken links in the chat window. This prevents Limechat users from opening URL links. Added additional regexp to fix it.
