### PR TITLE
Fix server capabilities handling

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -2985,14 +2985,50 @@
     [self startPongTimer];
 }
 
+// This is version 3.1 of the IRC capability negotiation protocol extension
+// ( http://ircv3.atheme.org/specification/capability-negotiation-3.1 )
 - (void)receiveCap:(IRCMessage*)m
 {
-    if (_isLoggedIn) return;
+    if (_isLoggedIn) {
+        [self send:CAP, @"END", nil];
+        return;
+    }
 
     NSString* command = [m paramAt:1];
     NSString* params = [[m paramAt:2] trim];
 
-    if ([command isEqualNoCase:@"ack"]) {
+    // reply from server indicating supported capabilities
+    if ([command isEqualNoCase:@"LS"]) {
+        LOG(@"Server supports capabilities: %@", params);
+
+        NSArray* caps = [params componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        NSMutableString* requestedCaps = [NSMutableString new];
+
+        for (NSString* cap in caps) {
+            if ([cap isEqualToString:@"znc.in/server-time"]) {
+                [requestedCaps appendString:@"znc.in/server-time "];
+
+            } else if ([cap isEqualToString:@"znc.in/server-time-iso"]) {
+                [requestedCaps appendString:@"znc.in/server-time-iso "];
+
+            } else if ([cap isEqualToString:@"sasl"]) {
+                if (_config.useSASL && _config.nick.length && _config.nickPassword.length) {
+                    [requestedCaps appendString:@"sasl "];
+                }
+            }
+        }
+
+        if (requestedCaps.length > 0) {
+            [self send:CAP, @"REQ", requestedCaps, nil];
+        }
+
+        // Client must send CAP END to continue registration
+        [self send:CAP, @"END", nil];
+
+    // accepted/enabled capabilities
+    } else if ([command isEqualNoCase:@"ACK"]) {
+        LOG(@"Using capabilities: %@", params);
+
         if ([params isEqualNoCase:@"sasl"]) {
             [self send:AUTHENTICATE, @"PLAIN", nil];
         }
@@ -3667,24 +3703,17 @@
     NSString* realName = _config.realName;
     if (!user.length) user = _config.nick;
     if (!realName.length) realName = _config.nick;
-
-    if (_config.useSASL) {
-        // If you send REQ to some servers (hyperion or etc) before PASS, the server refuses connection.
-        // To avoid this, do not send REQ if SASL setting is off.
-        [self send:CAP, @"REQ", @"znc.in/server-time", nil];
-        [self send:CAP, @"REQ", @"znc.in/server-time-iso", nil];
-
-        if (_config.nick.length && _config.nickPassword.length) {
-            [self send:CAP, @"REQ", @"sasl", nil];
-        }
-    }
-
+    
+    [self send:CAP, @"LS", nil];
+    
     if (_config.password.length) {
         [self send:PASS, _config.password, nil];
     }
-
+    
     [self send:NICK, _sentNick, nil];
     [self send:USER, user, [NSString stringWithFormat:@"%d", modeParam], @"*", realName, nil];
+
+    
 
     [self updateClientTitle];
 }


### PR DESCRIPTION
Sometimes users want to enable stuff like ZNC server-time without using SASL. The old assumption that some servers just randomly reject connections when `CAP REQ` is sent before PASS seems to have been somewhat mistaken. According to [the current spec](http://ircv3.atheme.org/specification/capability-negotiation-3.1), all we need is to send `CAP END` after `CAP REQ` to continue logging in.

So instead of testing for SASL being enabled before requesting any capabilities at all, I've moved the `CAP REQ`s to the receiveCap handler so that the client only requests capabilities that are supported by the server. While this isn't strictly necessary (the server will just send `CAP NAK`s) it's probably a good thing™. This also puts all the cap handling in one place.

Tested (works) with ZNC 1.0, hybrid, charybdis, ircd-seven (Freenode).
