### PR TITLE
Allow SSL Connection over SOCKS Proxy

### DIFF
--- a/Classes/Library/TCPClient.m
+++ b/Classes/Library/TCPClient.m
@@ -132,7 +132,8 @@
     else if (_useSocks) {
         [_conn useSocksProxyVersion:_socksVersion host:_proxyHost port:_proxyPort user:_proxyUser password:_proxyPassword];
     }
-    else if (_useSSL) {
+    
+    if (_useSSL) {
         [_conn useSSL];
     }
     return YES;


### PR DESCRIPTION
Currently SSL connection is not enabled if a SOCKS Proxy is set.
This allows to connect to the server over SSL over SOCKS Proxy.
