### PR TITLE
Fixed a bug that FileLogger may builds wrong year-part of filename during year-end and new year season

### DIFF
--- a/Classes/Library/FileLogger.m
+++ b/Classes/Library/FileLogger.m
@@ -92,7 +92,7 @@
     static NSDateFormatter* format = nil;
     if (!format) {
         format = [NSDateFormatter new];
-        [format setDateFormat:@"YYYY-MM-dd"];
+        [format setDateFormat:@"yyyy-MM-dd"];
     }
     NSString* date = [format stringFromDate:[NSDate date]];
     NSString* name = [[_client name] safeFileName];


### PR DESCRIPTION
As entitled above, this pull request fixes latent bug that FileLogger stores `LimeChat Transcripts` in wrong year-part of filename during year-end and new year season.
### Background

`NSDateFormatter` uses Unicode format, and symbol `Y` has special specification (unlike well-known `strftime` format).

As you can see in its Data Field Symbol Table,

http://unicode.org/reports/tr35/tr35-6.html#Date_Field_Symbol_Table

> Year (of "Week of Year"), used in ISO year-week calendar. May differ from calendar year.

symbol `Y` is not just calendar year but year of "week of year". It cause wrong year-part of filename in `Limechat Transcripts` folder during year-end and new year season. Strictly, it returns year of Thursday of the week.
### Problem

Because of this specification, for example, if you were running LimeChat during 2013-12-29 ~ 2013-12-31, you will find transcripts in that days like below. Because week of 2013-12-29 and after contains next-year's Thursday (2014-01-02).

```
LimeChat Transcripts/#(channelname)/2014-12-29_(servername).txt
LimeChat Transcripts/#(channelname)/2014-12-30_(servername).txt
LimeChat Transcripts/#(channelname)/2014-12-31_(servername).txt
```

Note that year part `2014` is wrong (`2013` is correct).
### Solution

Use `yyyy` (calendar year) instead of `YYYY`(year of "week of year") fixes this issue.

See also: http://d.hatena.ne.jp/mmasashi/20101111/1289489570 ( in Japanese )

Please note that this pull request does not care already stored transcripts with wrong year-part of filename, especially during 2014-12-29 to 2014-12-31 (stored in year-end of 2013, actually). When (real) year-end of 2014 has come, FileLogger will simply append transcripts to existing ones.
