### PR TITLE
Automatically mark scrollback when the log is in background.

### DIFF
--- a/Classes/Controllers/AppController.m
+++ b/Classes/Controllers/AppController.m
@@ -334,7 +334,7 @@
 
 - (void)windowDidResignKey:(NSNotification *)note
 {
-    IRCTreeItem* sel = world.selected;
+    IRCTreeItem* sel = _world.selected;
     if (sel) [sel.log unmark];
 }
 

--- a/Classes/Controllers/AppController.m
+++ b/Classes/Controllers/AppController.m
@@ -332,6 +332,12 @@
     [NSApp terminate:nil];
 }
 
+- (void)windowDidResignKey:(NSNotification *)note
+{
+    IRCTreeItem* sel = world.selected;
+    if (sel) [sel.log unmark];
+}
+
 #pragma mark - FieldEditorTextView Delegate
 
 - (BOOL)fieldEditorTextViewPaste:(id)sender;

--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -1825,6 +1825,11 @@
     if ([NSApp isActive] && _world.selected == t) return;
     if ([t isUnread]) return;
     [t setIsUnread:YES];
+    
+    LogController* channelLog = [t log];
+    if (![channelLog marked])
+        [channelLog mark];
+    
     [self reloadTree];
     [_world updateIcon];
 }
@@ -2363,6 +2368,11 @@
     if (target.isChannelName) {
         // channel
         IRCChannel* c = [self findChannel:target];
+        
+        id t = c ?: (id)self;
+        if (type != LINE_TYPE_NOTICE)
+            [self setUnreadState:t]; // Set unread before printing, so mark gets put above line
+        
         BOOL keyword = [self printBoth:(c ?: (id)target) type:type nick:nick text:text identified:identified timestamp:m.timestamp];
 
         if (type == LINE_TYPE_NOTICE) {
@@ -2370,8 +2380,6 @@
             [SoundPlayer play:[Preferences soundForEvent:USER_NOTIFICATION_CHANNEL_NOTICE]];
         }
         else {
-            id t = c ?: (id)self;
-            [self setUnreadState:t];
             if (keyword) [self setKeywordState:t];
 
             UserNotificationType kind = keyword ? USER_NOTIFICATION_HIGHLIGHT : USER_NOTIFICATION_CHANNEL_MSG;
@@ -2414,6 +2422,10 @@
             else if (c && type != LINE_TYPE_NOTICE && [Preferences bounceIconOnEveryPrivateMessage]) {
                 moreTalk = YES;
             }
+            
+            id t = c ?: (id)self;
+            if (type != LINE_TYPE_NOTICE)
+                [self setUnreadState:t]; // Set unread before printing, so mark gets put above line
 
             BOOL keyword = [self printBoth:c type:type nick:nick text:text identified:identified timestamp:m.timestamp];
 
@@ -2439,8 +2451,6 @@
                 [SoundPlayer play:[Preferences soundForEvent:USER_NOTIFICATION_TALK_NOTICE]];
             }
             else {
-                id t = c ?: (id)self;
-                [self setUnreadState:t];
                 if (keyword) [self setKeywordState:t];
                 if (newTalk || moreTalk) [self setNewTalkState:t];
 

--- a/Classes/IRC/IRCWorld.m
+++ b/Classes/IRC/IRCWorld.m
@@ -193,8 +193,10 @@
 {
     for (IRCClient* u in _clients) {
         u.isUnread = NO;
+        [u.log unmark];
         for (IRCChannel* c in u.channels) {
             c.isUnread = NO;
+            [c.log unmark];
         }
     }
     [self reloadTree];
@@ -955,6 +957,9 @@
 
 - (void)outlineViewSelectionDidChange:(NSNotification *)note
 {
+    if (self.selected)
+        [[self.selected log] unmark];
+        
     id nextItem = [_tree itemAtRow:[_tree selectedRow]];
 
     [_text focus];

--- a/Classes/Views/Log/LogController.h
+++ b/Classes/Views/Log/LogController.h
@@ -32,6 +32,7 @@
 @property (nonatomic) NSColor* initialBackgroundColor;
 @property (nonatomic) int maxLines;
 @property (nonatomic, readonly) BOOL viewingBottom;
+@property (nonatomic, readonly) BOOL marked;
 
 - (void)setUp;
 - (void)notifyDidBecomeVisible;

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -50,6 +50,7 @@
     BOOL _scrollBottom;
     int _scrollTop;
     NSMutableSet *_fetchingAvatarScreenNames;
+    BOOL _marked;
 }
 
 - (id)init
@@ -206,6 +207,8 @@
     ++_count;
 
     [self restorePosition];
+    
+    marked = YES;
 }
 
 - (void)unmark
@@ -219,6 +222,8 @@
         [[doc body] removeChild:e];
         --_count;
     }
+    
+    marked = NO;
 }
 
 - (void)goToMark

--- a/Classes/Views/Log/LogController.m
+++ b/Classes/Views/Log/LogController.m
@@ -208,7 +208,7 @@
 
     [self restorePosition];
     
-    marked = YES;
+    _marked = YES;
 }
 
 - (void)unmark
@@ -223,7 +223,7 @@
         --_count;
     }
     
-    marked = NO;
+    _marked = NO;
 }
 
 - (void)goToMark


### PR DESCRIPTION
I didn't see that having to manually mark the scrollback lines made much sense. To me it makes much more sense for this to automatically get set every time the log is unselected, or the whole window loses focus.

Also, curious what people think about this being an "always on" feature. I tend to be the person that avoids adding preferences if I can, but I don't feel super strongly about this one.
