### PR TITLE
Correct build error in Xcode 6.1 (#232)

### DIFF
--- a/Classes/Views/ThinSplitView.m
+++ b/Classes/Views/ThinSplitView.m
@@ -3,11 +3,11 @@
 
 #import "ThinSplitView.h"
 
-
 @implementation ThinSplitView
 {
     int _myDividerThickness;
 }
+@synthesize hidden = _hidden;
 
 - (void)setUp
 {


### PR DESCRIPTION
Added missing synthesize statement for _hidden in ThinSplitView to
correct build failure in Xcode 6.1. This fixes issue #232.