### PR TITLE
"Mark As Read" also resets keyword highlights

### DIFF
--- a/Classes/IRC/IRCWorld.m
+++ b/Classes/IRC/IRCWorld.m
@@ -193,8 +193,10 @@
 {
     for (IRCClient* u in _clients) {
         u.isUnread = NO;
+        u.isKeyword = NO;
         for (IRCChannel* c in u.channels) {
             c.isUnread = NO;
+            c.isKeyword = NO;
         }
     }
     [self reloadTree];


### PR DESCRIPTION
Otherwise the app icon stays badged, and the channel names stay highlighted. Which is kind of irritating :grin: