### PR TITLE
Add sanity check for _response in ImageSizeCheckClient.m

### DIFF
--- a/Classes/Library/ImageSizeCheckClient.m
+++ b/Classes/Library/ImageSizeCheckClient.m
@@ -66,6 +66,13 @@
 {
     if (_conn != sender) return;
 
+	/* If a user clicks a link that redirects to a data image, then 
+	 this value will not be NSHTTPURLResponse which results in a crash
+	 when trying to make a call to -allHeaderFields */
+	if ([_response isKindOfClass:[NSHTTPURLResponse class]] == NO) {
+		return;
+	}
+
     long long contentLength = 0;
     NSString* contentType;
     int statusCode = [_response statusCode];


### PR DESCRIPTION
When Limechat loads the contents of a URL it believes to be an image,
it follows redirects (the “Location” HTTP header). If a URL redirects
to a data image, such as:

data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAA
IBRAA7

then the value of the _response variable in the ImageSizeCheckClient.m
source file is NOT an instance of NSHTTPURLResponse. As a result,
calling -allHeaderFields or -statusCode on _response results in a crash.