### PR TITLE
Select channel with "/join #channel"

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -1323,6 +1323,13 @@
                 targetChannelName = [@"#" stringByAppendingString:targetChannelName];
             }
         }
+
+
+        // If we're already in this channel, show it to us
+        IRCChannel *channel = [self findChannel:targetChannelName];
+        if (channel) {
+            [_world select:channel];
+        }
     }
     else if ([cmd isEqualToString:INVITE]) {
         targetChannelName = [s getToken];


### PR DESCRIPTION
When you're in a lot of channels, it can be hard to find the one
you want. You may not even realize you're already in it!

When you're in this situation, entering "/join #channel" can feel
frustrating because nothing appears to happen. You might wonder, "Is the
server not responding?" No, you just forgot that you were already in
that channel.

This patch selects the channel you attempt to /join even if you're
already in it, alleviating this frustration and offering an alternative
channel-finding mechanism.