### PR TITLE
Proposal for Issue #284: Restoring messages

### DIFF
--- a/Classes/Dialogs/Preferences/PreferencesController.h
+++ b/Classes/Dialogs/Preferences/PreferencesController.h
@@ -8,7 +8,7 @@
 #define ThemeDidChangeNotification	@"ThemeDidChangeNotification"
 
 
-@interface PreferencesController : NSWindowController
+@interface PreferencesController : NSWindowController 
 
 @property (nonatomic, weak) id delegate;
 @property (nonatomic) NSString* fontDisplayName;
@@ -26,6 +26,8 @@
 @property (nonatomic) IBOutlet NSPopUpButton* transcriptFolderButton;
 @property (nonatomic) IBOutlet NSPopUpButton* themeButton;
 @property (nonatomic) IBOutlet NSTableView* soundsTable;
+@property (weak) IBOutlet NSTextField *savedMessagesLabel;
+@property (weak) IBOutlet NSStepper *savedMessagesStepper;
 
 - (void)show;
 
@@ -40,6 +42,7 @@
 - (void)onInputSelectFont:(id)sender;
 - (void)onOverrideFontChanged:(id)sender;
 - (void)onChangedTransparency:(id)sender;
+- (IBAction)changeNumberOfMessages:(NSSlider *)sender;
 
 @end
 

--- a/Classes/Dialogs/Preferences/PreferencesController.h
+++ b/Classes/Dialogs/Preferences/PreferencesController.h
@@ -42,6 +42,7 @@
 - (void)onInputSelectFont:(id)sender;
 - (void)onOverrideFontChanged:(id)sender;
 - (void)onChangedTransparency:(id)sender;
+
 - (IBAction)changeNumberOfMessages:(NSSlider *)sender;
 
 @end

--- a/Classes/Dialogs/Preferences/PreferencesController.m
+++ b/Classes/Dialogs/Preferences/PreferencesController.m
@@ -13,6 +13,8 @@
 #define PORT_MAX			65535
 #define PONG_INTERVAL_MIN	20
 
+#define MESSAGES_KEY @"numberOfSavedMessages"
+
 
 @implementation PreferencesController
 {
@@ -58,6 +60,14 @@
     }
 
     [self.window makeKeyAndOrderFront:nil];
+    
+    
+    NSNumber *maxMsg = [[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY];
+    if (![[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY]) {
+        maxMsg = @(10);
+    }
+    self.savedMessagesLabel.stringValue = [NSString stringWithFormat:@"%@",maxMsg];
+    self.savedMessagesStepper.integerValue = maxMsg.integerValue;
 }
 
 #pragma mark - KVC Properties
@@ -465,6 +475,7 @@
     [self onLayoutChanged:nil];
 }
 
+
 #pragma mark - Actions
 
 - (void)editTable:(NSTableView*)table
@@ -486,10 +497,18 @@
     [self performSelector:@selector(editTable:) withObject:_excludeWordsTable afterDelay:0.01];
 }
 
+
 - (void)onLayoutChanged:(id)sender
 {
     NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
     [nc postNotificationName:ThemeDidChangeNotification object:nil userInfo:nil];
+}
+
+- (IBAction)changeNumberOfMessages:(NSStepper *)sender
+{
+    self.savedMessagesLabel.stringValue = [NSString stringWithFormat:@"%d",sender.intValue];
+    [[NSUserDefaults standardUserDefaults] setObject:@(sender.intValue) forKey:MESSAGES_KEY];
+    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 #pragma mark - NSWindow Delegate

--- a/Classes/Dialogs/Preferences/PreferencesController.m
+++ b/Classes/Dialogs/Preferences/PreferencesController.m
@@ -61,15 +61,19 @@
 
     [self.window makeKeyAndOrderFront:nil];
     
-    
+    [self updateLabels];
+}
+-(void)updateLabels
+{
+    //Load preferences
     NSNumber *maxMsg = [[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY];
     if (![[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY]) {
         maxMsg = @(10);
     }
+    //Adapt label and stepper
     self.savedMessagesLabel.stringValue = [NSString stringWithFormat:@"%@",maxMsg];
     self.savedMessagesStepper.integerValue = maxMsg.integerValue;
 }
-
 #pragma mark - KVC Properties
 
 - (void)setFontDisplayName:(NSString*)value

--- a/Classes/IRC/IRCChannel.m
+++ b/Classes/IRC/IRCChannel.m
@@ -125,16 +125,8 @@
     _isNamesInit = NO;
     _isWhoInit = NO;
     [self reloadMemberList];
+    [self loadSavedMessages];
     
-    
-    //Can maybe be seperated into a function later on
-    NSString *key =[NSString stringWithFormat:@"log-%@",self.name];
- //   [[NSUserDefaults standardUserDefaults] setObject:[NSKeyedArchiver archivedDataWithRootObject:[NSMutableArray new]] forKey:key];
- //   [[NSUserDefaults standardUserDefaults] synchronize];
-    NSMutableArray *savedMsg = [NSKeyedUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] objectForKey:key]];
-    for (IRCMessage *m in savedMsg) {
-        [self.client receivePrivmsgAndNotice:m];
-    }
     
     
 }
@@ -145,6 +137,15 @@
     [_members removeAllObjects];
     _isOp = NO;
     [self reloadMemberList];
+}
+-(void)loadSavedMessages
+{
+    //Send every saved message over to the IRCClient
+    NSString *key =[NSString stringWithFormat:@"log-%@",self.name];
+    NSMutableArray *savedMsg = [NSKeyedUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] objectForKey:key]];
+    for (IRCMessage *m in savedMsg) {
+        [self.client receivePrivmsgAndNotice:m];
+    }
 }
 
 - (BOOL)print:(LogLine*)line

--- a/Classes/IRC/IRCChannel.m
+++ b/Classes/IRC/IRCChannel.m
@@ -8,6 +8,7 @@
 #import "MemberListViewCell.h"
 #import "NSStringHelper.h"
 
+#import "IRCMessage.h"
 
 @implementation IRCChannel
 {
@@ -124,6 +125,18 @@
     _isNamesInit = NO;
     _isWhoInit = NO;
     [self reloadMemberList];
+    
+    
+    //Can maybe be seperated into a function later on
+    NSString *key =[NSString stringWithFormat:@"log-%@",self.name];
+ //   [[NSUserDefaults standardUserDefaults] setObject:[NSKeyedArchiver archivedDataWithRootObject:[NSMutableArray new]] forKey:key];
+ //   [[NSUserDefaults standardUserDefaults] synchronize];
+    NSMutableArray *savedMsg = [NSKeyedUnarchiver unarchiveObjectWithData:[[NSUserDefaults standardUserDefaults] objectForKey:key]];
+    for (IRCMessage *m in savedMsg) {
+        [self.client receivePrivmsgAndNotice:m];
+    }
+    
+    
 }
 
 - (void)deactivate

--- a/Classes/IRC/IRCClient.h
+++ b/Classes/IRC/IRCClient.h
@@ -87,7 +87,7 @@ typedef enum {
 
 - (void)createChannelListDialog;
 
-//Current solution: make the function public, so that it can be called from IRCChannel
+//Make the function public, so that it can be called from IRCChannel
 - (void)receivePrivmsgAndNotice:(IRCMessage*)m;
 
 

--- a/Classes/IRC/IRCClient.h
+++ b/Classes/IRC/IRCClient.h
@@ -14,7 +14,7 @@
 #import "ListDialog.h"
 #import "Timer.h"
 #import "HostResolver.h"
-
+#import "IRCMessage.h"
 
 @class IRCWorld;
 
@@ -86,5 +86,10 @@ typedef enum {
 - (int)indexOfTalkChannel;
 
 - (void)createChannelListDialog;
+
+//Current solution: make the function public, so that it can be called from IRCChannel
+- (void)receivePrivmsgAndNotice:(IRCMessage*)m;
+
+
 
 @end

--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -28,6 +28,9 @@
 
 #define TOLERANCE_TIME 4
 
+#define MESSAGES_KEY @"numberOfSavedMessages"
+#define STANDARD_SAVED_MESSAGES 10
+
 @implementation IRCClient
 {
     IRCConnection* _conn;
@@ -1634,7 +1637,12 @@
     if (m.timestamp > current.longLongValue - TOLERANCE_TIME) {
         [savedMsg addObject:m];
     }
-    if (savedMsg.count > 10) {
+
+    int maxSavedMsg = [[[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY] intValue];
+    if (![[NSUserDefaults standardUserDefaults] objectForKey:MESSAGES_KEY]) {
+        maxSavedMsg = STANDARD_SAVED_MESSAGES;
+    }
+    if (savedMsg.count > maxSavedMsg) {
         [savedMsg removeObjectAtIndex:0];
     }
     [[NSUserDefaults standardUserDefaults] setObject:[NSKeyedArchiver archivedDataWithRootObject:savedMsg] forKey:key];

--- a/Classes/IRC/IRCMessage.h
+++ b/Classes/IRC/IRCMessage.h
@@ -5,7 +5,7 @@
 #import "IRCPrefix.h"
 
 
-@interface IRCMessage : NSObject
+@interface IRCMessage : NSObject <NSCoding>
 
 @property (nonatomic) time_t timestamp;
 @property (nonatomic) IRCPrefix* sender;

--- a/Classes/IRC/IRCMessage.m
+++ b/Classes/IRC/IRCMessage.m
@@ -143,4 +143,29 @@
     return ms;
 }
 
+#pragma mark NSCoding Protocol
+
+-(void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:@(self.timestamp) forKey:@"timestamp"];
+    [aCoder encodeObject:self.sender forKey:@"sender"];
+    [aCoder encodeObject:self.command forKey:@"command"];
+    [aCoder encodeObject:@(self.numericReply) forKey:@"numericReply"];
+    [aCoder encodeObject:self.params forKey:@"params"];
+
+}
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    
+    self = [super init];
+    if (self) {
+        self.timestamp = [[aDecoder decodeObjectForKey:@"timestamp"] longLongValue];
+        self.sender = [aDecoder decodeObjectForKey:@"sender"];
+        self.command = [aDecoder decodeObjectForKey:@"command"];
+        self.numericReply = [[aDecoder decodeObjectForKey:@"numericReply"] intValue];
+        self.params = [aDecoder decodeObjectForKey:@"params"];
+        
+    }
+    return self;
+}
 @end

--- a/Classes/IRC/IRCPrefix.h
+++ b/Classes/IRC/IRCPrefix.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 
-@interface IRCPrefix : NSObject
+@interface IRCPrefix : NSObject <NSCoding>
 
 @property (nonatomic) NSString* raw;
 @property (nonatomic) NSString* nick;

--- a/Classes/IRC/IRCPrefix.m
+++ b/Classes/IRC/IRCPrefix.m
@@ -17,5 +17,27 @@
     }
     return self;
 }
+-(void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [aCoder encodeObject:self.raw forKey:@"raw"];
+    [aCoder encodeObject:self.nick forKey:@"nick"];
+    [aCoder encodeObject:self.user forKey:@"user"];
+    [aCoder encodeObject:self.address forKey:@"address"];
+    [aCoder encodeObject:@(self.isServer) forKey:@"isServer"];
 
+}
+-(id)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super init];
+    if (self) {
+        self.raw = [aDecoder decodeObjectForKey:@"raw"];
+        self.nick = [aDecoder decodeObjectForKey:@"nick"];
+        self.user = [aDecoder decodeObjectForKey:@"user"];
+        self.address = [aDecoder decodeObjectForKey:@"address"];
+        self.isServer = [[aDecoder decodeObjectForKey:@"isServer"] boolValue];
+
+        
+    }
+    return self;
+}
 @end

--- a/English.lproj/Preferences.xib
+++ b/English.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="13F1603" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
-        <deployment version="1070" defaultVersion="1080" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="4514"/>
+        <deployment version="1070" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="PreferencesController">
@@ -12,6 +12,8 @@
                 <outlet property="hotKey" destination="879" id="4354"/>
                 <outlet property="keywordsArrayController" destination="4310" id="4333"/>
                 <outlet property="keywordsTable" destination="2123" id="4342"/>
+                <outlet property="savedMessagesLabel" destination="M9u-2H-dx6" id="tao-He-MCz"/>
+                <outlet property="savedMessagesStepper" destination="Pi4-J3-dbf" id="8du-Uc-JcC"/>
                 <outlet property="soundsTable" destination="101" id="4488"/>
                 <outlet property="themeButton" destination="248" id="4402"/>
                 <outlet property="transcriptFolderButton" destination="108" id="4398"/>
@@ -19,8 +21,8 @@
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
-        <customObject id="-3" userLabel="Application"/>
-        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" wantsToBeColor="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window" customClass="DialogWindow">
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="5" userLabel="Window" customClass="DialogWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="682" y="550" width="443" height="397"/>
@@ -112,7 +114,7 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="2123">
-                                                        <rect key="frame" x="0.0" y="0.0" width="190" height="152"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="190" height="19"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -179,7 +181,7 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" id="2514">
-                                                        <rect key="frame" x="0.0" y="0.0" width="190" height="152"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="190" height="19"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
@@ -249,9 +251,9 @@
                                                 <action selector="remove:" target="4313" id="4340"/>
                                                 <binding destination="4313" name="enabled2" keyPath="canRemove" previousBinding="2595" id="4353">
                                                     <dictionary key="options">
-                                                        <integer key="NSNotApplicablePlaceholder" value="-1"/>
-                                                        <integer key="NSNoSelectionPlaceholder" value="-1"/>
                                                         <integer key="NSMultipleValuesPlaceholder" value="-1"/>
+                                                        <integer key="NSNoSelectionPlaceholder" value="-1"/>
+                                                        <integer key="NSNotApplicablePlaceholder" value="-1"/>
                                                         <integer key="NSNullPlaceholder" value="-1"/>
                                                     </dictionary>
                                                 </binding>
@@ -533,6 +535,32 @@
                                                 <binding destination="1247" name="value" keyPath="values.Preferences.General.showRename" id="4492"/>
                                             </connections>
                                         </button>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="M9u-2H-dx6">
+                                            <rect key="frame" x="123" y="144" width="21" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="10" id="dcm-xQ-urR">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" id="Pi4-J3-dbf">
+                                            <rect key="frame" x="147" y="138" width="19" height="27"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <stepperCell key="cell" continuous="YES" alignment="left" maxValue="30" doubleValue="10" id="GIZ-z6-gN3"/>
+                                            <connections>
+                                                <action selector="changeNumberOfMessages:" target="-2" id="YbA-Nc-MLY"/>
+                                            </connections>
+                                        </stepper>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="uuR-e1-Y91">
+                                            <rect key="frame" x="15" y="144" width="117" height="17"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved messages:" id="hTl-d0-XGd">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                 </view>
                             </tabViewItem>
@@ -780,7 +808,7 @@
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="4272" id="101">
-                                                        <rect key="frame" x="0.0" y="0.0" width="403" height="178"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="403" height="19"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>


### PR DESCRIPTION
For each active channel, in- and outgoing messages are saved and
restored after a restart of the client. The number of saved messages
can be changed from 0 to 30 (default: 10) within the preferences under
the ‚log‘ tab.
