### PR TITLE
Implemented system sounds lookup, fixes #156

### DIFF
--- a/Classes/Dialogs/Preferences/PreferencesController.m
+++ b/Classes/Dialogs/Preferences/PreferencesController.m
@@ -207,7 +207,14 @@
 {
     static NSArray* ary;
     if (!ary) {
-        ary = [NSArray arrayWithObjects:@"-", @"Beep", @"Basso", @"Blow", @"Bottle", @"Frog", @"Funk", @"Glass", @"Hero", @"Morse", @"Ping", @"Pop", @"Purr", @"Sosumi", @"Submarine", @"Tink", nil];
+        NSMutableArray* arr = [NSMutableArray arrayWithObject:@"-"];
+        for (NSString *path in [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory,
+                                                                    NSAllDomainsMask, YES) objectEnumerator])
+            for (NSString *soundFile in [[NSFileManager defaultManager]
+                                         enumeratorAtPath:[path stringByAppendingPathComponent:@"Sounds"]])
+                if ([NSSound soundNamed:[soundFile stringByDeletingPathExtension]])
+                    [arr addObject:[soundFile stringByDeletingPathExtension]];
+        ary = [arr copy];
     }
     return ary;
 }


### PR DESCRIPTION
This pull request changes the lookup function to a function, which, on first invocation, looks through all the possible library directories, adding, if applicable, the sounds from them to an array, an immutable copy of which is returned on subsequent invocations.