### PR TITLE
Fixes text input color (dark mode)

### DIFF
--- a/Classes/Preferences/OtherTheme.m
+++ b/Classes/Preferences/OtherTheme.m
@@ -76,8 +76,8 @@
     _logScrollerMarkColor = [self loadColor:@"log-view", @"scroller-highlight-color", nil] ?: [NSColor magentaColor];
 
     _inputTextFont = [self loadFont:@"input-text"] ?: [NSFont systemFontOfSize:0];
-    _inputTextBgColor = [self loadColor:@"input-text", @"background-color", nil] ?: [NSColor whiteColor];
-    _inputTextColor = [self loadColor:@"input-text", @"color", nil] ?: [NSColor blackColor];
+    _inputTextBgColor = [self loadColor:@"input-text", @"background-color", nil] ?: [NSColor textBackgroundColor];
+    _inputTextColor = [self loadColor:@"input-text", @"color", nil] ?: [NSColor textColor];
     _inputTextSelColor = [self loadColor:@"input-text", @"selected", @"background-color", nil] ?: [NSColor selectedTextBackgroundColor];
 
     _treeFont = [self loadFont:@"server-tree"] ?: [NSFont systemFontOfSize:0];


### PR DESCRIPTION
Hi, just started using LimeChat.
I noticed that text input color is not visible when using the default theme in dark mode.

<img width="1070" alt="before" src="https://user-images.githubusercontent.com/6495600/112537844-73693500-8daf-11eb-83c2-b29489027156.png">

<img width="1093" alt="after" src="https://user-images.githubusercontent.com/6495600/112537866-7d8b3380-8daf-11eb-9623-aed1ead742c3.png">

