### PR TITLE
ensure authzid and authcid are equal in SASL PLAIN

### DIFF
--- a/Classes/IRC/IRCClient.m
+++ b/Classes/IRC/IRCClient.m
@@ -3016,7 +3016,7 @@
         if (!user.length) user = _config.nick;
         if (!pass.length) pass = @"";
 
-        NSString* base = [NSString stringWithFormat:@"%@\0%@\0%@", _config.nick, user, pass];
+        NSString* base = [NSString stringWithFormat:@"%@\0%@\0%@", user, user, pass];
         NSData* data = [base dataUsingEncoding:_encoding];
         NSString* authStr = [GTMBase64 stringByEncodingData:data];
         [self send:AUTHENTICATE, authStr, nil];


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc4616#section-2
https://datatracker.ietf.org/doc/html/rfc4422#section-2

authzid ("authorization id") is optional, authcid ("authentication id") is
mandatory; best practice in IRC is to omit authzid or set it equal to
authcid. Previous Limechat behavior was to send the nickname as the authzid
which will break authentication on major networks (e.g. Libera) if the
nickname is not registered with NickServ.

Thanks for your time!